### PR TITLE
Add TUFHelperLite support to level cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint . --ext js,jsx --max-warnings 0"
   },
   "dependencies": {
+    "@adofai-ipc/client": "^0.1.0",
     "@discordapp/twemoji": "^15.1.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/src/components/cards/LevelCard/LevelCard.jsx
+++ b/src/components/cards/LevelCard/LevelCard.jsx
@@ -9,7 +9,7 @@ import { AddToPackPopup } from "@/components/popups/Packs";
 import { SongPopup } from "@/components/popups/Songs";
 import { ArtistPopup } from "@/components/popups/Artists";
 import { useDifficultyContext } from "@/contexts/DifficultyContext";
-import { EditIcon, SteamIcon, DownloadIcon, VideoLinkIcon, PassIcon, LikeIcon, PackIcon, DragHandleIcon, MetronomeIcon, ChartIcon, TimeIcon } from "@/components/common/icons";
+import { EditIcon, SteamIcon, DownloadIcon, VideoLinkIcon, PassIcon, LikeIcon, PackIcon, DragHandleIcon, MetronomeIcon, ChartIcon, TimeIcon, TUFHelperLiteIcon } from "@/components/common/icons";
 import { clampFloat, formatCreatorDisplay } from "@/utils/Utility";
 import { getPrimaryVideoLink } from "@/utils/videoLink";
 import { ABILITIES, hasBit } from "@/utils/Abilities";
@@ -24,6 +24,16 @@ import {
 import { formatAutoTilecountTooltip, formatDuration } from "@/utils/levelHelpers";
 import { Tooltip } from "react-tooltip";
 import MarqueeText from "@/components/common/display/MarqueeText/MarqueeText";
+import {
+  checkTufHelperLiteDownloadedIds,
+  checkTufHelperLiteHealth,
+  checkTufHelperLiteJobs,
+  getTufHelperLiteDownloadState,
+  invokeTufHelperLiteIpc,
+  useTufHelperLiteDownloadedIds,
+  useTufHelperLiteHealth,
+  useTufHelperLiteJobs,
+} from "@/hooks/useTufHelperLiteIpc";
 
 /** Curation type names hidden from the difficulty-arc curation icons */
 const HIDDEN_CURATION_ARC_TYPE_NAMES = new Set(['C0', 'V0']);
@@ -102,6 +112,16 @@ const LevelCard = ({
   const hasSongPopup = (level?.songs && level.songs.length > 0) ? true : false;
   const hasArtistPopup = (level?.artists && level.artists.length > 0) ? true : false;
   const levelDetailTo = level?.id != null ? `/levels/${level.id}` : '#';
+  const tufHelperLiteHealth = useTufHelperLiteHealth();
+  const tufHelperLiteJobs = useTufHelperLiteJobs();
+  const tufHelperLiteDownloadedIds = useTufHelperLiteDownloadedIds();
+  const tufHelperLiteDownload = getTufHelperLiteDownloadState(
+    tufHelperLiteHealth,
+    tufHelperLiteJobs.jobs,
+    tufHelperLiteDownloadedIds.levelIdSet,
+    level,
+    dlLink,
+  );
 
   useBodyScrollLock(showEditPopup || showAddToPackPopup || showSongPopup || showArtistPopup);
 
@@ -121,6 +141,34 @@ const LevelCard = ({
   const handleEditClick = (e) => { e.stopPropagation(); setShowEditPopup(true); };
   const handleAddToPackClick = (e) => { e.stopPropagation(); setShowAddToPackPopup(true); };
   const handleDeleteClick = (e) => { e.stopPropagation(); onDeleteItem?.(packItem); };
+  const handleTufHelperLiteClick = async (e) => {
+    e.stopPropagation();
+
+    if (!tufHelperLiteHealth.isAvailable || !dlLinkValid || tufHelperLiteDownload.state === 'downloading') {
+      return;
+    }
+
+    try {
+      if (level?.id != null) {
+        await invokeTufHelperLiteIpc('level.open-from-id', {
+          id: String(level.id),
+          source: 'tuforums-levels',
+          openAfterDownload: true,
+        });
+      } else {
+        await invokeTufHelperLiteIpc('level.open-from-url', {
+          url: dlLink,
+          source: 'tuforums-levels',
+          openAfterDownload: true,
+        });
+      }
+
+      void checkTufHelperLiteJobs();
+      void checkTufHelperLiteDownloadedIds();
+    } catch {
+      void checkTufHelperLiteHealth();
+    }
+  };
 
   // Determine glow class based on abilities
   const getGlowClass = () => {
@@ -237,6 +285,7 @@ const LevelCard = ({
     showVideo = true, 
     showDownload = true, 
     showSteam = true, 
+    showTufHelperLite = true,
     showAddToPack = false,
     showDelete = false,
     editMarginZero = false
@@ -281,6 +330,24 @@ const LevelCard = ({
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
             <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
           </svg>
+        </button>
+      )}
+      {showTufHelperLite && showDownload && dlLinkValid && tufHelperLiteHealth.isAvailable && (
+        <button
+          type="button"
+          className="tufhelperlite-button"
+          onClick={handleTufHelperLiteClick}
+          title="Open with TUFHelperLite"
+          aria-label="Open with TUFHelperLite"
+          disabled={tufHelperLiteDownload.state === 'downloading'}
+          data-available="true"
+          data-state={tufHelperLiteDownload.state}
+          style={{ '--tufhelperlite-progress': `${Math.round(tufHelperLiteDownload.progress * 100)}%` }}
+        >
+          <span className="tufhelperlite-button__icon-stack" aria-hidden="true">
+            <TUFHelperLiteIcon className="tufhelperlite-button__icon tufhelperlite-button__icon--base" size="100%" />
+            <TUFHelperLiteIcon className="tufhelperlite-button__icon tufhelperlite-button__icon--color" size="100%" />
+          </span>
         </button>
       )}
     </div>
@@ -489,7 +556,7 @@ const LevelCard = ({
           <Link className="level-card__link-wrap" to={levelDetailTo} aria-label={getSongDisplayName(level)}>
             {renderLinkContent({ showLikes: false })}
           </Link>
-          {renderDownloadLinks({ showAddToPack: false, editMarginZero: true, showDelete: canEdit })}
+          {renderDownloadLinks({ showAddToPack: false, editMarginZero: true, showDelete: canEdit, showTufHelperLite: false })}
         </div>
 
         {renderPopups()}

--- a/src/components/cards/LevelCard/levelcard.css
+++ b/src/components/cards/LevelCard/levelcard.css
@@ -1,4 +1,10 @@
 /* tuf-search: #LevelCard #levelCard #cards */
+@property --tufhelperlite-progress {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 0%;
+}
+
 .level-card {
   position: relative;
   display: flex;
@@ -180,6 +186,7 @@
   width: 2.5rem;
 }
 .level-card .downloads-wrapper a svg,
+.level-card .tufhelperlite-button svg,
 .level-card .edit-button svg {
   height: 100%;
   width: 100%;
@@ -192,6 +199,7 @@
 }
 
 .level-card .downloads-wrapper a svg:hover,
+.level-card .tufhelperlite-button:not(:disabled) svg:hover,
 .level-card .edit-button svg:hover {
   transform: scale(1.1);
 }
@@ -205,6 +213,59 @@
   padding: 0;
   cursor: pointer;
   transition: all 0.2s;
+}
+
+.level-card .tufhelperlite-button {
+  display: block;
+  height: 2.5rem;
+  width: 2.5rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.level-card .tufhelperlite-button:disabled {
+  cursor: not-allowed;
+}
+
+.level-card .tufhelperlite-button[data-state="downloading"] {
+  transition: --tufhelperlite-progress 0.45s ease-out;
+}
+
+.level-card .tufhelperlite-button__icon-stack {
+  position: relative;
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.level-card .tufhelperlite-button__icon {
+  position: absolute;
+  inset: 0;
+}
+
+.level-card .tufhelperlite-button__icon--base {
+  opacity: 0;
+}
+
+.level-card .tufhelperlite-button__icon--color {
+  opacity: 1;
+}
+
+.level-card .tufhelperlite-button[data-state="downloading"] .tufhelperlite-button__icon--base {
+  filter: grayscale(1) brightness(0.8) contrast(1.1);
+  opacity: 0.42;
+}
+
+.level-card .tufhelperlite-button[data-state="downloading"] .tufhelperlite-button__icon--color {
+  -webkit-mask-image: conic-gradient(from 0deg at 50% 50%, #000 0 var(--tufhelperlite-progress, 0%), transparent var(--tufhelperlite-progress, 0%) 100%);
+          mask-image: conic-gradient(from 0deg at 50% 50%, #000 0 var(--tufhelperlite-progress, 0%), transparent var(--tufhelperlite-progress, 0%) 100%);
+}
+
+.level-card.compact .tufhelperlite-button {
+  height: 1.65rem;
+  width: 1.65rem;
 }
 
 .level-card.compact .add-to-pack-button {

--- a/src/components/common/icons/TUFHelperLiteIcon.jsx
+++ b/src/components/common/icons/TUFHelperLiteIcon.jsx
@@ -1,0 +1,108 @@
+// tuf-search: #TUFHelperLiteIcon #tufhelperliteIcon #icons
+import React from 'react';
+
+export const TUFHelperLiteIcon = ({ size = 24, className = '', ...props }) => {
+  const id = React.useId().replace(/:/g, '');
+  const bgId = `tufhelperlite-bg-${id}`;
+  const redId = `tufhelperlite-red-${id}`;
+  const blueId = `tufhelperlite-blue-${id}`;
+  const softId = `tufhelperlite-soft-${id}`;
+
+  return (
+    <svg
+      width={size || '100%'}
+      height={size || '100%'}
+      viewBox="0 0 64 64"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <defs>
+        <radialGradient id={bgId} cx="50%" cy="45%" r="70%">
+          <stop offset="0%" stopColor="#102b6f" />
+          <stop offset="55%" stopColor="#071a48" />
+          <stop offset="100%" stopColor="#020817" />
+        </radialGradient>
+        <radialGradient id={redId} cx="38%" cy="36%" r="58%">
+          <stop offset="0%" stopColor="#ffe37a" />
+          <stop offset="48%" stopColor="#ff553d" />
+          <stop offset="100%" stopColor="#b8152e" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient id={blueId} cx="64%" cy="64%" r="62%">
+          <stop offset="0%" stopColor="#82fff5" />
+          <stop offset="45%" stopColor="#4a75ff" />
+          <stop offset="100%" stopColor="#2a58ff" stopOpacity="0" />
+        </radialGradient>
+        <filter id={softId} x="-40%" y="-40%" width="180%" height="180%">
+          <feGaussianBlur stdDeviation="1.25" />
+        </filter>
+      </defs>
+
+      <g className="tufhelperlite-icon__background tufhelperlite-icon__background--mono">
+        <rect x="4" y="4" width="56" height="56" rx="14" fill={`url(#${bgId})`} />
+        <g fill="#ffffff">
+          <circle cx="15" cy="15" r="1" opacity="0.85" />
+          <circle cx="25" cy="12" r="0.75" opacity="0.65" />
+          <circle cx="39" cy="14" r="0.85" opacity="0.75" />
+          <circle cx="50" cy="26" r="0.8" opacity="0.7" />
+          <circle cx="13" cy="40" r="0.7" opacity="0.55" />
+          <circle cx="32" cy="54" r="0.85" opacity="0.75" />
+          <circle cx="50" cy="48" r="1" opacity="0.8" />
+        </g>
+        <rect x="4.75" y="4.75" width="54.5" height="54.5" rx="13.25" stroke="#ffffff" strokeOpacity="0.16" strokeWidth="1.5" />
+      </g>
+
+      <g className="tufhelperlite-icon__background tufhelperlite-icon__background--color">
+        <rect x="4" y="4" width="56" height="56" rx="14" fill={`url(#${bgId})`} />
+        <g fill="#ffffff">
+          <circle cx="15" cy="15" r="1" opacity="0.85" />
+          <circle cx="25" cy="12" r="0.75" opacity="0.65" />
+          <circle cx="39" cy="14" r="0.85" opacity="0.75" />
+          <circle cx="50" cy="26" r="0.8" opacity="0.7" />
+          <circle cx="13" cy="40" r="0.7" opacity="0.55" />
+          <circle cx="32" cy="54" r="0.85" opacity="0.75" />
+          <circle cx="50" cy="48" r="1" opacity="0.8" />
+        </g>
+        <rect x="4.75" y="4.75" width="54.5" height="54.5" rx="13.25" stroke="#ffffff" strokeOpacity="0.16" strokeWidth="1.5" />
+      </g>
+
+      <g className="tufhelperlite-icon__foreground">
+        <path
+          d="M18 29C20.5 16.5 36.5 11 48 19"
+          stroke="#ff463b"
+          strokeWidth="8"
+          strokeLinecap="round"
+          filter={`url(#${softId})`}
+        />
+        <path
+          d="M46 35C43.5 48 27.5 53 16 45"
+          stroke="#3388ff"
+          strokeWidth="8"
+          strokeLinecap="round"
+          filter={`url(#${softId})`}
+        />
+        <circle cx="20" cy="29" r="8.5" fill={`url(#${redId})`} />
+        <circle cx="45" cy="35" r="8.5" fill={`url(#${blueId})`} />
+
+        <path
+          d="M21 44C26 47.5 34 48 40 44"
+          stroke="#54b7ff"
+          strokeWidth="3"
+          strokeLinecap="round"
+          opacity="0.65"
+        />
+        <path
+          d="M43 20C38 16.5 30 16 24 20"
+          stroke="#ff795e"
+          strokeWidth="3"
+          strokeLinecap="round"
+          opacity="0.65"
+        />
+      </g>
+    </svg>
+  );
+};
+
+export default TUFHelperLiteIcon;

--- a/src/components/common/icons/index.js
+++ b/src/components/common/icons/index.js
@@ -58,6 +58,7 @@ import ScoreIcon from './ScoreIcon';
 import ChartIcon from './ChartIcon';
 import TimeIcon from './TimeIcon';
 import AdofaiIcon from './AdofaiIcon';
+import TUFHelperLiteIcon from './TUFHelperLiteIcon';
 import { SettingsIcon } from './SettingsIcon';
 import { TUFStellarIcon } from './TUFStellarIcon';
 import { HeartIcon } from './HeartIcon';
@@ -124,6 +125,7 @@ export {
     ChartIcon,
     TimeIcon,
     AdofaiIcon,
+    TUFHelperLiteIcon,
     SettingsIcon,
     TUFStellarIcon,
     HeartIcon,

--- a/src/hooks/useTufHelperLiteIpc.js
+++ b/src/hooks/useTufHelperLiteIpc.js
@@ -1,0 +1,335 @@
+import { useSyncExternalStore } from "react";
+import { tryConnect } from "@adofai-ipc/client";
+
+const TUFHELPER_LITE_NAMESPACE = 'tufhelperlite';
+const TUFHELPER_LITE_HEALTH_METHOD = 'health';
+const IPC_PORT_START = 32145;
+const IPC_PORT_END = 32155;
+const IPC_HEALTH_POLL_MS = 2500;
+const IPC_JOBS_POLL_MS = 1000;
+const IPC_DOWNLOADED_IDS_POLL_MS = 2500;
+const IPC_HEALTH_TIMEOUT_MS = 800;
+const IPC_HEALTH_MISSES_BEFORE_OFFLINE = 3;
+
+const tufHelperLiteHealthListeners = new Set();
+let tufHelperLiteHealthSnapshot = { isAvailable: false, isChecking: true, port: null };
+let tufHelperLiteHealthPollId = null;
+let tufHelperLiteClient = null;
+let tufHelperLiteNamespaceClient = null;
+let isTufHelperLiteHealthChecking = false;
+let tufHelperLiteConsecutiveHealthMisses = 0;
+
+const tufHelperLiteJobsListeners = new Set();
+let tufHelperLiteJobsSnapshot = { jobs: [] };
+let tufHelperLiteJobsPollId = null;
+let isTufHelperLiteJobsChecking = false;
+
+const tufHelperLiteDownloadedIdsListeners = new Set();
+let tufHelperLiteDownloadedIdsSnapshot = { levelIds: [], levelIdSet: new Set() };
+let tufHelperLiteDownloadedIdsPollId = null;
+let isTufHelperLiteDownloadedIdsChecking = false;
+
+const getTufHelperLiteHealthSnapshot = () => tufHelperLiteHealthSnapshot;
+const getTufHelperLiteJobsSnapshot = () => tufHelperLiteJobsSnapshot;
+const getTufHelperLiteDownloadedIdsSnapshot = () => tufHelperLiteDownloadedIdsSnapshot;
+
+const setTufHelperLiteHealthSnapshot = (nextSnapshot) => {
+  if (
+    tufHelperLiteHealthSnapshot.isAvailable === nextSnapshot.isAvailable &&
+    tufHelperLiteHealthSnapshot.isChecking === nextSnapshot.isChecking &&
+    tufHelperLiteHealthSnapshot.port === nextSnapshot.port
+  ) {
+    return;
+  }
+
+  tufHelperLiteHealthSnapshot = nextSnapshot;
+  tufHelperLiteHealthListeners.forEach((listener) => listener());
+};
+
+const setTufHelperLiteJobsSnapshot = (nextSnapshot) => {
+  tufHelperLiteJobsSnapshot = nextSnapshot;
+  tufHelperLiteJobsListeners.forEach((listener) => listener());
+};
+
+const setTufHelperLiteDownloadedIdsSnapshot = (nextSnapshot) => {
+  tufHelperLiteDownloadedIdsSnapshot = nextSnapshot;
+  tufHelperLiteDownloadedIdsListeners.forEach((listener) => listener());
+};
+
+const normalizeAdofaiIpcResponse = (data) => {
+  if (!data || typeof data !== 'object') return data;
+
+  if ('Ok' in data || 'Result' in data || 'Error' in data || 'Id' in data) {
+    return {
+      ok: data.Ok,
+      result: data.Result,
+      error: data.Error,
+      id: data.Id,
+    };
+  }
+
+  return data;
+};
+
+const adofaiIpcFetch = async (...args) => {
+  const response = await fetch(...args);
+  const requestUrl = String(args[0] instanceof Request ? args[0].url : args[0]);
+
+  if (!requestUrl.endsWith('/ipc')) {
+    return response;
+  }
+
+  const text = await response.clone().text();
+  if (!text) return response;
+
+  try {
+    const normalized = normalizeAdofaiIpcResponse(JSON.parse(text));
+    return new Response(JSON.stringify(normalized), {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  } catch {
+    return response;
+  }
+};
+
+const getTufHelperLitePort = (client) => {
+  const port = Number(new URL(client.baseUrl).port);
+  return Number.isFinite(port) ? port : null;
+};
+
+const connectTufHelperLiteIpc = async () => {
+  const client = await tryConnect({
+    startPort: IPC_PORT_START,
+    endPort: IPC_PORT_END,
+    fetch: adofaiIpcFetch,
+    timeoutMs: IPC_HEALTH_TIMEOUT_MS,
+  });
+
+  tufHelperLiteClient = client;
+  tufHelperLiteNamespaceClient = client.namespace(TUFHELPER_LITE_NAMESPACE);
+  return client;
+};
+
+const clearTufHelperLiteClient = () => {
+  tufHelperLiteClient = null;
+  tufHelperLiteNamespaceClient = null;
+};
+
+export const invokeTufHelperLiteIpc = async (method, params = {}) => {
+  if (!tufHelperLiteNamespaceClient) {
+    await connectTufHelperLiteIpc();
+  }
+
+  if (!tufHelperLiteNamespaceClient) {
+    throw new Error('TUFHelperLite IPC port is not available.');
+  }
+
+  try {
+    return await tufHelperLiteNamespaceClient.call(method, params, `tufhelperlite-${method}`);
+  } catch {
+    clearTufHelperLiteClient();
+    throw new Error('TUFHelperLite IPC returned an error.');
+  }
+};
+
+export const checkTufHelperLiteHealth = async () => {
+  if (isTufHelperLiteHealthChecking) return;
+  isTufHelperLiteHealthChecking = true;
+
+  try {
+    setTufHelperLiteHealthSnapshot({ ...tufHelperLiteHealthSnapshot, isChecking: true });
+
+    const client = tufHelperLiteClient ?? await connectTufHelperLiteIpc();
+    const workingPort = getTufHelperLitePort(client);
+
+    await client.namespace(TUFHELPER_LITE_NAMESPACE).call(TUFHELPER_LITE_HEALTH_METHOD);
+
+    if (workingPort != null) {
+      tufHelperLiteConsecutiveHealthMisses = 0;
+    }
+
+    const shouldStayAvailable =
+      workingPort == null &&
+      tufHelperLiteHealthSnapshot.isAvailable &&
+      tufHelperLiteConsecutiveHealthMisses < IPC_HEALTH_MISSES_BEFORE_OFFLINE;
+
+    setTufHelperLiteHealthSnapshot({
+      isAvailable: workingPort != null || shouldStayAvailable,
+      isChecking: false,
+      port: workingPort ?? (shouldStayAvailable ? tufHelperLiteHealthSnapshot.port : null),
+    });
+  } catch {
+    clearTufHelperLiteClient();
+    tufHelperLiteConsecutiveHealthMisses += 1;
+
+    const shouldStayAvailable =
+      tufHelperLiteHealthSnapshot.isAvailable &&
+      tufHelperLiteConsecutiveHealthMisses < IPC_HEALTH_MISSES_BEFORE_OFFLINE;
+
+    setTufHelperLiteHealthSnapshot({
+      isAvailable: shouldStayAvailable,
+      isChecking: false,
+      port: shouldStayAvailable ? tufHelperLiteHealthSnapshot.port : null,
+    });
+  } finally {
+    isTufHelperLiteHealthChecking = false;
+  }
+};
+
+export const checkTufHelperLiteJobs = async () => {
+  if (isTufHelperLiteJobsChecking) return;
+  if (!tufHelperLiteHealthSnapshot.isAvailable || !tufHelperLiteHealthSnapshot.port) {
+    setTufHelperLiteJobsSnapshot({ jobs: [] });
+    return;
+  }
+
+  isTufHelperLiteJobsChecking = true;
+
+  try {
+    const result = await invokeTufHelperLiteIpc('level.jobs', {});
+    setTufHelperLiteJobsSnapshot({ jobs: result?.Jobs || result?.jobs || [] });
+  } catch {
+    setTufHelperLiteJobsSnapshot({ jobs: [] });
+  } finally {
+    isTufHelperLiteJobsChecking = false;
+  }
+};
+
+export const checkTufHelperLiteDownloadedIds = async () => {
+  if (isTufHelperLiteDownloadedIdsChecking) return;
+  if (!tufHelperLiteHealthSnapshot.isAvailable || !tufHelperLiteHealthSnapshot.port) {
+    setTufHelperLiteDownloadedIdsSnapshot({ levelIds: [], levelIdSet: new Set() });
+    return;
+  }
+
+  isTufHelperLiteDownloadedIdsChecking = true;
+
+  try {
+    const result = await invokeTufHelperLiteIpc('level.downloaded-ids', {});
+    const levelIds = result?.LevelIds || result?.levelIds || [];
+    setTufHelperLiteDownloadedIdsSnapshot({
+      levelIds,
+      levelIdSet: new Set(levelIds.map(String)),
+    });
+  } catch {
+    setTufHelperLiteDownloadedIdsSnapshot({ levelIds: [], levelIdSet: new Set() });
+  } finally {
+    isTufHelperLiteDownloadedIdsChecking = false;
+  }
+};
+
+const subscribeTufHelperLiteHealth = (listener) => {
+  tufHelperLiteHealthListeners.add(listener);
+
+  if (tufHelperLiteHealthPollId == null) {
+    void checkTufHelperLiteHealth();
+    tufHelperLiteHealthPollId = window.setInterval(checkTufHelperLiteHealth, IPC_HEALTH_POLL_MS);
+  }
+
+  return () => {
+    tufHelperLiteHealthListeners.delete(listener);
+
+    if (tufHelperLiteHealthListeners.size === 0 && tufHelperLiteHealthPollId != null) {
+      window.clearInterval(tufHelperLiteHealthPollId);
+      tufHelperLiteHealthPollId = null;
+    }
+  };
+};
+
+const subscribeTufHelperLiteJobs = (listener) => {
+  tufHelperLiteJobsListeners.add(listener);
+
+  if (tufHelperLiteJobsPollId == null) {
+    void checkTufHelperLiteJobs();
+    tufHelperLiteJobsPollId = window.setInterval(checkTufHelperLiteJobs, IPC_JOBS_POLL_MS);
+  }
+
+  return () => {
+    tufHelperLiteJobsListeners.delete(listener);
+
+    if (tufHelperLiteJobsListeners.size === 0 && tufHelperLiteJobsPollId != null) {
+      window.clearInterval(tufHelperLiteJobsPollId);
+      tufHelperLiteJobsPollId = null;
+    }
+  };
+};
+
+const subscribeTufHelperLiteDownloadedIds = (listener) => {
+  tufHelperLiteDownloadedIdsListeners.add(listener);
+
+  if (tufHelperLiteDownloadedIdsPollId == null) {
+    void checkTufHelperLiteDownloadedIds();
+    tufHelperLiteDownloadedIdsPollId = window.setInterval(checkTufHelperLiteDownloadedIds, IPC_DOWNLOADED_IDS_POLL_MS);
+  }
+
+  return () => {
+    tufHelperLiteDownloadedIdsListeners.delete(listener);
+
+    if (tufHelperLiteDownloadedIdsListeners.size === 0 && tufHelperLiteDownloadedIdsPollId != null) {
+      window.clearInterval(tufHelperLiteDownloadedIdsPollId);
+      tufHelperLiteDownloadedIdsPollId = null;
+    }
+  };
+};
+
+const normalizeTufHelperLiteUrl = (url) => (url || '').trim().replace(/\/+$/, '').toLowerCase();
+
+const getJobValue = (job, key) => job?.[key] ?? job?.[key.charAt(0).toLowerCase() + key.slice(1)];
+
+export const findTufHelperLiteJob = (jobs, level, dlLink) => {
+  const levelId = level?.id == null ? '' : String(level.id);
+  const normalizedDlLink = normalizeTufHelperLiteUrl(dlLink);
+
+  return jobs
+    .filter((job) => {
+      const jobLevelId = getJobValue(job, 'LevelId');
+      const sourceUrl = normalizeTufHelperLiteUrl(getJobValue(job, 'SourceUrl'));
+      const directUrl = normalizeTufHelperLiteUrl(getJobValue(job, 'DirectUrl'));
+
+      return (
+        (levelId && String(jobLevelId || '') === levelId) ||
+        (normalizedDlLink && (sourceUrl === normalizedDlLink || directUrl === normalizedDlLink))
+      );
+    })
+    .sort((a, b) => (getJobValue(b, 'UpdatedAtUnixMs') || 0) - (getJobValue(a, 'UpdatedAtUnixMs') || 0))[0];
+};
+
+export const getTufHelperLiteDownloadState = (health, jobs, downloadedLevelIdSet, level, dlLink) => {
+  if (!health.isAvailable) {
+    return { state: 'offline', progress: 0, job: null };
+  }
+
+  const job = findTufHelperLiteJob(jobs, level, dlLink);
+  const status = String(getJobValue(job, 'Status') || '').toLowerCase();
+  if (job && (status === 'queued' || status === 'running')) {
+    const progress = Math.max(0, Math.min(1, Number(getJobValue(job, 'Progress')) || 0));
+    return { state: 'downloading', progress, job };
+  }
+
+  const levelId = level?.id == null ? '' : String(level.id);
+  if (levelId && downloadedLevelIdSet?.has(levelId)) {
+    return { state: 'downloaded', progress: 1, job: null };
+  }
+
+  return { state: 'not-downloaded', progress: 0, job };
+};
+
+export const useTufHelperLiteHealth = () => useSyncExternalStore(
+  subscribeTufHelperLiteHealth,
+  getTufHelperLiteHealthSnapshot,
+  getTufHelperLiteHealthSnapshot,
+);
+
+export const useTufHelperLiteJobs = () => useSyncExternalStore(
+  subscribeTufHelperLiteJobs,
+  getTufHelperLiteJobsSnapshot,
+  getTufHelperLiteJobsSnapshot,
+);
+
+export const useTufHelperLiteDownloadedIds = () => useSyncExternalStore(
+  subscribeTufHelperLiteDownloadedIds,
+  getTufHelperLiteDownloadedIdsSnapshot,
+  getTufHelperLiteDownloadedIdsSnapshot,
+);

--- a/src/pages/common/Level/LevelPage/LevelPage.jsx
+++ b/src/pages/common/Level/LevelPage/LevelPage.jsx
@@ -29,6 +29,7 @@ import toast from 'react-hot-toast';
 import { hasFlag, permissionFlags } from "@/utils/UserPermissions";
 import { normalizeLevelSearchQuery } from '@/utils/normalizeEntitySearchQuery';
 import { getDefaultQSliderRange } from '@/utils/getDefaultQSliderRange';
+import { useTufHelperLiteDownloadedIds, useTufHelperLiteHealth } from '@/hooks/useTufHelperLiteIpc';
 
 const limit = 50;
 
@@ -129,6 +130,9 @@ const LevelPage = ({
   const [searchInput, setSearchInput] = useState(query);
   const [showTagsInCards, setShowTagsInCards] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [showDownloadedOnly, setShowDownloadedOnly] = useState(false);
+  const tufHelperLiteHealth = useTufHelperLiteHealth();
+  const tufHelperLiteDownloadedIds = useTufHelperLiteDownloadedIds();
 
   const showC0V0CurationIcons = useMemo(() => {
     const includedIds = collectFacetDomainIncludedIds(levelFacetFilters.curationTypes);
@@ -139,6 +143,23 @@ const LevelPage = ({
       return hiddenNames.has(name);
     });
   }, [levelFacetFilters.curationTypes, curationTypes]);
+
+  const visibleLevelsData = useMemo(() => {
+    if (!showDownloadedOnly || !levelsData) return levelsData;
+
+    return levelsData.filter((level) => {
+      const levelId = level?.id == null ? '' : String(level.id);
+      return levelId && tufHelperLiteDownloadedIds.levelIdSet.has(levelId);
+    });
+  }, [levelsData, showDownloadedOnly, tufHelperLiteDownloadedIds.levelIdSet]);
+
+  const visibleTotalLevels = showDownloadedOnly ? (visibleLevelsData?.length ?? 0) : totalLevels;
+  const downloadedOnlyCanFindMore =
+    showDownloadedOnly &&
+    tufHelperLiteHealth.isAvailable &&
+    (visibleLevelsData?.length ?? 0) < tufHelperLiteDownloadedIds.levelIds.length;
+  const listHasMore = showDownloadedOnly ? hasMore && downloadedOnlyCanFindMore : hasMore;
+  const listLoader = showDownloadedOnly && !loadingMore ? null : <div className="loader loader-relative" />;
 
   // Debounced request runner: filter/query changes wait 500ms before firing
   // and reset the timer + abort any in-flight request when called again.
@@ -424,6 +445,34 @@ const LevelPage = ({
       cancelled = true;
     };
   }, [pageNumber]);
+
+  useEffect(() => {
+    if (!tufHelperLiteHealth.isAvailable && showDownloadedOnly) {
+      setShowDownloadedOnly(false);
+    }
+  }, [tufHelperLiteHealth.isAvailable, showDownloadedOnly]);
+
+  useEffect(() => {
+    if (
+      showDownloadedOnly &&
+      tufHelperLiteHealth.isAvailable &&
+      tufHelperLiteDownloadedIds.levelIds.length > 0 &&
+      levelsData?.length > 0 &&
+      visibleLevelsData?.length === 0 &&
+      listHasMore &&
+      !loadingMore
+    ) {
+      setPageNumber((prevPageNumber) => prevPageNumber + 1);
+    }
+  }, [
+    showDownloadedOnly,
+    tufHelperLiteHealth.isAvailable,
+    tufHelperLiteDownloadedIds.levelIds.length,
+    levelsData?.length,
+    visibleLevelsData?.length,
+    listHasMore,
+    loadingMore,
+  ]);
 
   function handleFilterOpen() {
     setFilterOpen(!filterOpen);
@@ -763,6 +812,19 @@ const LevelPage = ({
               </div>
               )}
             </div>
+            {tufHelperLiteHealth.isAvailable && (
+              <label className="tufhelperlite-downloaded-filter">
+                <input
+                  type="checkbox"
+                  checked={showDownloadedOnly}
+                  onChange={(event) => setShowDownloadedOnly(event.target.checked)}
+                />
+                <span className="tufhelperlite-downloaded-filter__switch" aria-hidden="true" />
+                <span className="tufhelperlite-downloaded-filter__label">
+                  {t('level.settingExp.showDownloadedOnly')}
+                </span>
+              </label>
+            )}
           </div>
             </CollapsibleContent>
           </Collapsible>
@@ -817,7 +879,7 @@ const LevelPage = ({
             </CollapsibleContent>
           </Collapsible>
         </div>
-        <span className="total-search-results">{t('level.totalResults', { count: totalLevels })}</span>
+        <span className="total-search-results">{t('level.totalResults', { count: visibleTotalLevels })}</span>
         <div className="view-mode-section">
           <p>{t('level.settingExp.viewMode')}</p>
           <div className="view-mode-buttons">
@@ -855,17 +917,17 @@ const LevelPage = ({
         {levelsData ? (
         <VirtualList
           style={{ paddingBottom: "7rem", overflow: "visible", position: "relative", zIndex: 5 }}
-          items={levelsData}
+          items={visibleLevelsData}
           defaultItemHeight={viewMode === 'compact' ? 64 : 90}
           customScrollParent={customScrollParent}
           loadingMore={loadingMore}
           loadMore={() => {
-            if (!loadingMore && hasMore && levelsData?.length > 0) {
+            if (!loadingMore && listHasMore && levelsData?.length > 0) {
               setPageNumber((prevPageNumber) => prevPageNumber + 1);
             }
           }}
-          hasMore={hasMore && levelsData.length > 0}
-          loader={<div className="loader loader-relative" />}
+          hasMore={listHasMore && levelsData.length > 0}
+          loader={listLoader}
           endMessage={
             <p className="end-message">
               <b>{t('level.infScroll.end')}</b>
@@ -882,6 +944,7 @@ const LevelPage = ({
             />
           )}
           computeItemKey={(index, l) => l?.id ?? index}
+          stateKey={showDownloadedOnly ? 'levels-downloaded-only' : 'levels-all'}
         />
         ) : (
           <div className="loader-shell loader-shell--tall">

--- a/src/pages/common/Level/LevelPage/levelpage.css
+++ b/src/pages/common/Level/LevelPage/levelpage.css
@@ -31,6 +31,72 @@
   position: relative;
   margin-bottom: 1rem;
 }
+
+.level-page .level-body .tufhelperlite-downloaded-filter {
+  position: absolute;
+  right: 2rem;
+  bottom: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  background-color: var(--color-white-t10);
+  color: var(--color-white);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  -webkit-user-select: none;
+  user-select: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.level-page .level-body .tufhelperlite-downloaded-filter:hover {
+  background-color: var(--color-white-t20);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.level-page .level-body .tufhelperlite-downloaded-filter input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.level-page .level-body .tufhelperlite-downloaded-filter__switch {
+  position: relative;
+  width: 2.1rem;
+  height: 1.15rem;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.22);
+  flex: 0 0 auto;
+  transition: background-color 0.2s ease;
+}
+
+.level-page .level-body .tufhelperlite-downloaded-filter__switch::after {
+  content: "";
+  position: absolute;
+  top: 0.15rem;
+  left: 0.15rem;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  background-color: var(--color-white);
+  transition: transform 0.2s ease;
+}
+
+.level-page .level-body .tufhelperlite-downloaded-filter input:checked + .tufhelperlite-downloaded-filter__switch {
+  background-color: #18c8ff;
+}
+
+.level-page .level-body .tufhelperlite-downloaded-filter input:checked + .tufhelperlite-downloaded-filter__switch::after {
+  transform: translateX(0.95rem);
+}
+
+.level-page .level-body .tufhelperlite-downloaded-filter__label {
+  white-space: nowrap;
+}
 .level-page .level-body .spacer-setting {
   width: 100%;
   height: 1px;
@@ -323,7 +389,13 @@
 
   .sort-class {
     padding: 1rem;
-    max-height: 200px;
+    max-height: none;
+  }
+
+  .level-page .level-body .tufhelperlite-downloaded-filter {
+    position: static;
+    width: fit-content;
+    margin-top: 1rem;
   }
 
   .level-page .level-body .filter {
@@ -608,7 +680,6 @@
     width: 100%;
   }
 }
-
 
 
 

--- a/src/translations/languages/cn/pages/level.json
+++ b/src/translations/languages/cn/pages/level.json
@@ -50,7 +50,8 @@
     "specialDifficulties": "特殊难度",
     "curationTypes": "精选关卡类型",
     "tags": "标签",
-    "myLikes": "我的收藏"
+    "myLikes": "我的收藏",
+    "showDownloadedOnly": "仅显示已下载"
   },
   "totalResults": "共 {{count}} 个结果",
   "infScroll": {
@@ -59,4 +60,4 @@
   "loading": {
     "difficulties": "正在加载关卡……"
   }
-} 
+}

--- a/src/translations/languages/en/pages/level.json
+++ b/src/translations/languages/en/pages/level.json
@@ -50,7 +50,8 @@
     "specialDifficulties": "Special Difficulties",
     "curationTypes": "Curation Types",
     "tags": "Tags",
-    "myLikes": "My Likes"
+    "myLikes": "My Likes",
+    "showDownloadedOnly": "Show Downloaded Only"
   },
   "totalResults": "{{count}} Total Results",
   "infScroll": {
@@ -59,4 +60,4 @@
   "loading": {
     "difficulties": "Loading difficulties..."
   }
-} 
+}

--- a/src/translations/languages/fr/pages/level.json
+++ b/src/translations/languages/fr/pages/level.json
@@ -40,9 +40,10 @@
     "headerSort": "Paramètres de triage",
     "sortRecent": "Récent",
     "filterDiffs": "Difficulté",
-    "sortRandom": "Aléatoire"
+    "sortRandom": "Aléatoire",
+    "showDownloadedOnly": "Afficher seulement les niveaux téléchargés"
   },
   "infScroll": {
     "end": "Vous avez atteint la fin!"
   }
-} 
+}

--- a/src/translations/languages/kr/pages/level.json
+++ b/src/translations/languages/kr/pages/level.json
@@ -50,7 +50,8 @@
     "specialDifficulties": "특수 난이도",
     "curationTypes": "큐레이션 유형",
     "tags": "태그",
-    "myLikes": "내가 좋아요한 레벨"
+    "myLikes": "내가 좋아요한 레벨",
+    "showDownloadedOnly": "다운로드한 레벨만 보기"
   },
   "totalResults": "총 {{count}}개",
   "infScroll": {

--- a/src/translations/languages/pl/pages/level.json
+++ b/src/translations/languages/pl/pages/level.json
@@ -48,7 +48,8 @@
     "sortClears": "Sortuj według ilości przejść",
     "viewMode": "Tryb przeglądania",
     "clearedLevels": "Z przejściami",
-    "deletedLevels": "Usunięte poziomy"
+    "deletedLevels": "Usunięte poziomy",
+    "showDownloadedOnly": "Pokaż tylko pobrane"
   },
   "infScroll": {
     "end": "Koniec listy poziomów"
@@ -56,4 +57,4 @@
   "loading": {
     "difficulties": "Problemy z ładowaniem..."
   }
-} 
+}


### PR DESCRIPTION
## Add TUFHelperLite support to level cards

This PR adds optional TUFHelperLite support to the level list.

When TUFHelperLite is running, downloadable level cards show an extra button that downloads the level and opens it directly in ADOFAI. If the mod is not running, the button stays hidden and the page works as before.

## Changes

- Added a TUFHelperLite button to downloadable level cards
- Added the TUFHelperLite icon and download progress animation
- Added polling for active downloads and downloaded level IDs
- Added a `Show Downloaded Only` filter
- Added translations for the new filter
- Added `@adofai-ipc/client` for communication with the local mod

`@adofai-ipc/client` is a small package I made for communicating with AdofaiIpc from JavaScript and TypeScript. It handles IPC requests and automatically searches ports `32145` through `32155`, so it still works when the default port is already in use.

## Notes

This feature requires both AdofaiIpc and TUFHelperLite. Both are completely optional, and users without them installed should not notice any changes. To learn more about AdofaiIpc, check out the [[AdofaiIpc repository]](https://github.com/KGH1113/adofai-ipc).

## Screenshot
<img width="800" height="450" alt="showcase" src="https://github.com/user-attachments/assets/876be164-aabb-4419-a680-f61380383418" />

